### PR TITLE
Update the appdata

### DIFF
--- a/com.lakoliu.Furtherance.appdata.xml
+++ b/com.lakoliu.Furtherance.appdata.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>com.lakoliu.Furtherance</id>
+	<launchable type="desktop-id">com.lakoliu.Furtherance.desktop</launchable>
+	<name>Furtherance</name>
+	<summary>Track your time without being tracked</summary>
+	<developer_name>Ricky Kresslein</developer_name>
+	
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-3.0-or-later</project_license>
+	
+	<description>
+		<p>
+		Furtherance is a time tracking app built for GNOME with Rust
+		and GTK4. In addition to tracking time spent on tasks, you can edit that
+		time, delete entries, and change settings. It even has idle detection.
+		</p>
+	</description>
+	
+	<url type="homepage">https://furtherance.app</url>
+	<url type="bugtracker">https://github.com/lakoliu/Furtherance/issues</url>
+	<url type="donation">https://www.paypal.com/donate/?hosted_button_id=TLYY8YZ424VRL</url>
+        
+ 	<screenshots>
+    		<screenshot type="default">
+      			<image>https://github.com/lakoliu/Furtherance/raw/main/data/screenshots/furtherance-screenshot-main.png</image>
+    		</screenshot>
+    		<screenshot>
+      			<image>https://github.com/lakoliu/Furtherance/raw/main/data/screenshots/furtherance-screenshot-task-details.png</image>
+    		</screenshot>
+    		<screenshot>
+      			<image>https://github.com/lakoliu/Furtherance/raw/main/data/screenshots/furtherance-screenshot-edit-task.png</image>
+    		</screenshot>
+    		<screenshot>
+      			<image>https://github.com/lakoliu/Furtherance/raw/main/data/screenshots/furtherance-screenshot-settings.png</image>
+    		</screenshot>
+  	</screenshots>
+	
+	<content_rating type="oars-1.1" />
+	
+	<releases>
+		<release version="1.5.4" date="2022-09-14"/>
+	</releases>
+	  
+</component>
+

--- a/com.lakoliu.Furtherance.json
+++ b/com.lakoliu.Furtherance.json
@@ -42,6 +42,10 @@
                     "url" : "https://github.com/lakoliu/Furtherance/releases/download/v1.5.4/furtherance-offline-1.5.4.tar.xz",
                     "sha256" : "fffc90c9d9caa3001bb51d4d4f0bc13e03c464719c0b9df23bb96c601b004507"
                 }
+                {
+		    "type": "file",
+          	    "path": "com.lakoliu.Furtherance.appdata.xml"
+        	}
             ]
         }
     ]

--- a/com.lakoliu.Furtherance.json
+++ b/com.lakoliu.Furtherance.json
@@ -41,7 +41,7 @@
                     "type" : "archive",
                     "url" : "https://github.com/lakoliu/Furtherance/releases/download/v1.5.4/furtherance-offline-1.5.4.tar.xz",
                     "sha256" : "fffc90c9d9caa3001bb51d4d4f0bc13e03c464719c0b9df23bb96c601b004507"
-                }
+                },
                 {
 		    "type": "file",
           	    "path": "com.lakoliu.Furtherance.appdata.xml"


### PR DESCRIPTION
I recently visit the flathub site of the [Furtherance app](https://flathub.org/apps/details/com.lakoliu.Furtherance "Furtherance app"), and I see there is no screenshot of this app. So, I try out to add the appdata file which may help this app to show screenshot on the flathub page.

Thank you for creating this awesome app.