### PR TITLE
Update runtime for GNOME 44

### DIFF
--- a/com.lakoliu.Furtherance.json
+++ b/com.lakoliu.Furtherance.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.lakoliu.Furtherance",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Update runtime for GNOME 44 because GNOME 43 runtime is no longer supported as of September 20, 2023