### PR TITLE
End of life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "end-of-life": "Application has been renamed to io.unobserved.furtherance",
     "end-of-life-rebase": "io.unobserved.furtherance",
-    "skip-appstream-check": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
     "end-of-life": "Application has been renamed to io.unobserved.furtherance",
-    "end-of-life-rebase": "io.unobserved.furtherance",
+    "end-of-life-rebase": "io.unobserved.furtherance"
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "end-of-life": "Application has been renamed to io.unobserved.furtherance",
+    "end-of-life-rebase": "io.unobserved.furtherance",
+    "skip-appstream-check": true
+}


### PR DESCRIPTION
Furtherance can now be found at io.unobserved.furtherance. It was re-written using the Iced framework and this app-id and the GTK version is now end of life.