### PR TITLE
End of Life

### DIFF
--- a/com.lakoliu.Furtherance.json
+++ b/com.lakoliu.Furtherance.json
@@ -40,8 +40,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/lakoliu/Furtherance/releases/download/v1.8.3/furtherance-offline-1.8.3.tar.xz",
-                    "sha256" : "6480aa0ca4838a87187282977e22392be691fbcc913cdc176968f7d0ac2e1639"
+                    "url" : "https://github.com/unobserved-io/Furtherance/releases/download/v1.8.3/furtherance-offline-1.8.3.tar.xz",
+                    "sha256" : "401183d239937a1194018b2bbdbc50f9f6fa943ffca48d36c70f2e95c7c825c8"
                 }
             ]
         }

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "end-of-life": "Application has been renamed to io.unobserved.furtherance",
     "end-of-life-rebase": "io.unobserved.furtherance",
-    "skip-appstream-check": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
     "end-of-life": "Application has been renamed to io.unobserved.furtherance",
-    "end-of-life-rebase": "io.unobserved.furtherance",
+    "end-of-life-rebase": "io.unobserved.furtherance"
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "end-of-life": "Application has been renamed to io.unobserved.furtherance",
+    "end-of-life-rebase": "io.unobserved.furtherance",
+    "skip-appstream-check": true
+}


### PR DESCRIPTION
Furtherance can now be found at io.unobserved.furtherance. It was re-written using the Iced framework and this app-id and the GTK version is now end of life.